### PR TITLE
Fix playback position sync with Plex (#20)

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/PlexSyncScrobbleWorker.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/PlexSyncScrobbleWorker.kt
@@ -48,7 +48,6 @@ class PlexSyncScrobbleWorker(
         val trackId = inputData.requireInt(TRACK_ID_ARG)
         val playbackState = inputData.requireString(TRACK_STATE_ARG)
         val trackProgress = inputData.requireLong(TRACK_POSITION_ARG)
-        val playbackTimeStamp = inputData.requireLong(PLAYBACK_TIME_STAMP)
         val bookProgress = inputData.requireLong(BOOK_PROGRESS)
         try {
             workerScope.launch(Injector.get().unhandledExceptionHandler()) {
@@ -64,7 +63,7 @@ class PlexSyncScrobbleWorker(
                     Injector.get().plexMediaService().progress(
                         ratingKey = trackId.toString(),
                         offset = trackProgress.toString(),
-                        playbackTime = playbackTimeStamp,
+                        playbackTime = trackProgress,
                         playQueueItemId = track.playQueueItemID,
                         key = "${MediaItemTrack.PARENT_KEY_PREFIX}$trackId",
                         // IMPORTANT: Plex normally marks as finished at 90% progress, but it
@@ -125,7 +124,6 @@ class PlexSyncScrobbleWorker(
         const val TRACK_ID_ARG = "Track ID"
         const val TRACK_STATE_ARG = "State"
         const val TRACK_POSITION_ARG = "Track position"
-        const val PLAYBACK_TIME_STAMP = "Original play time"
         const val BOOK_PROGRESS = "Book progress"
 
         fun makeWorkerData(
@@ -133,14 +131,12 @@ class PlexSyncScrobbleWorker(
             playbackState: String,
             trackProgress: Long,
             bookProgress: Long,
-            playbackTimeStamp: Long = System.currentTimeMillis()
         ): Data {
             require(trackId != TRACK_NOT_FOUND)
             return workDataOf(
                 TRACK_ID_ARG to trackId,
                 TRACK_POSITION_ARG to trackProgress,
                 TRACK_STATE_ARG to playbackState,
-                PLAYBACK_TIME_STAMP to playbackTimeStamp,
                 BOOK_PROGRESS to bookProgress
             )
         }

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/ProgressUpdater.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/ProgressUpdater.kt
@@ -159,7 +159,6 @@ class SimpleProgressUpdater @Inject constructor(
                     trackId,
                     playbackState,
                     trackProgress,
-                    currentTime,
                     bookProgress
                 )
             }
@@ -170,7 +169,6 @@ class SimpleProgressUpdater @Inject constructor(
         trackId: Int,
         playbackState: String,
         trackProgress: Long,
-        currentTime: Long,
         bookProgress: Long
     ) {
         val syncWorkerConstraints =
@@ -179,7 +177,6 @@ class SimpleProgressUpdater @Inject constructor(
             trackId = trackId,
             playbackState = playbackState,
             trackProgress = trackProgress,
-            playbackTimeStamp = currentTime,
             bookProgress = bookProgress
         )
         val worker = OneTimeWorkRequestBuilder<PlexSyncScrobbleWorker>()


### PR DESCRIPTION
Plex requires the playbackTime to be the track progress, not the current epoch