### PR TITLE
Paginated sync to server

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/BookRepository.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/BookRepository.kt
@@ -131,6 +131,8 @@ interface IBookRepository {
 
     /** Loads an [Audiobook] in from the network */
     suspend fun fetchBookAsync(bookId: Int): Audiobook?
+
+    suspend fun refreshDataPaginated()
 }
 
 @Singleton
@@ -175,6 +177,64 @@ class BookRepository @Inject constructor(
         } ?: return
         //    ^^^ quit on network failure- nothing below matters without new books from server
 
+        val localBooks = withContext(Dispatchers.IO) { bookDao.getAudiobooks() }
+
+        val mergedBooks = networkBooks.map { networkBook ->
+            val localBook = localBooks.find { it.id == networkBook.id }
+            if (localBook != null) {
+                // [Audiobook.merge] chooses fields depending on [Audiobook.lastViewedAt]
+                return@map Audiobook.merge(network = networkBook, local = localBook)
+            } else {
+                return@map networkBook
+            }
+        }
+
+        // remove books which have been deleted from server
+        val networkIds = networkBooks.map { it.id }
+        val removedFromNetwork = localBooks.filter { localBook ->
+            !networkIds.contains(localBook.id)
+        }
+
+        Timber.i("Removed from network: ${removedFromNetwork.map { it.title }}")
+        withContext(Dispatchers.IO) {
+            val removed = bookDao.removeAll(removedFromNetwork.map { it.id.toString() })
+            Timber.i("Removed $removed items from DB")
+
+            Timber.i("Loaded books: $mergedBooks")
+            bookDao.insertAll(mergedBooks)
+        }
+    }
+
+    @Throws(Throwable::class)
+    override suspend fun refreshDataPaginated() {
+        if (prefsRepo.offlineMode) {
+            return
+        }
+
+        prefsRepo.lastRefreshTimeStamp = System.currentTimeMillis()
+        val networkBooks: MutableList<Audiobook> = mutableListOf()
+        withContext(Dispatchers.IO) {
+            try {
+                val libraryId = plexPrefsRepo.library?.id ?: return@withContext
+                var booksLeft = 1L
+                // Maximum number of pages of data we fetch. Failsafe in case of bad data from the
+                // server since we don't want infinite loops. This limits us to a maximum 1,000,000
+                // tracks for now
+                val maxIterations = 5000
+                var i = 0
+                while (booksLeft > 0 && i < maxIterations) {
+                    val response = plexMediaService
+                        .retrieveAlbumPage(libraryId, i * 100)
+                        .plexMediaContainer
+                    booksLeft = response.totalSize - (response.offset + response.size)
+                    networkBooks.addAll(response.asAudiobooks())
+                    i++
+                }
+            } catch (t: Throwable) {
+                Timber.i("Failed to retrieve books: $t")
+            }
+        }
+        //    ^^^ quit on network failure- nothing below matters without new books from server
 
         val localBooks = withContext(Dispatchers.IO) { bookDao.getAudiobooks() }
 

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/TrackRepository.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/TrackRepository.kt
@@ -9,6 +9,7 @@ import io.github.mattpvaughn.chronicle.data.model.MediaItemTrack
 import io.github.mattpvaughn.chronicle.data.model.NO_AUDIOBOOK_FOUND_ID
 import io.github.mattpvaughn.chronicle.data.sources.MediaSource
 import io.github.mattpvaughn.chronicle.data.sources.plex.PlexMediaService
+import io.github.mattpvaughn.chronicle.data.sources.plex.PlexPrefsRepo
 import io.github.mattpvaughn.chronicle.data.sources.plex.model.MediaType
 import io.github.mattpvaughn.chronicle.data.sources.plex.model.asTrackList
 import kotlinx.coroutines.Dispatchers
@@ -122,13 +123,16 @@ interface ITrackRepository {
          */
         const val TRACK_NOT_FOUND: Int = -23
     }
+
+    suspend fun refreshDataPaginated()
 }
 
 @Singleton
 class TrackRepository @Inject constructor(
     private val trackDao: TrackDao,
     private val prefsRepo: PrefsRepo,
-    private val plexMediaService: PlexMediaService
+    private val plexMediaService: PlexMediaService,
+    private val plexPrefs: PlexPrefsRepo
 ) : ITrackRepository {
 
     @Throws(Throwable::class)
@@ -137,6 +141,39 @@ class TrackRepository @Inject constructor(
             return
         }
         loadAllTracksAsync()
+    }
+
+    override suspend fun refreshDataPaginated() {
+        if (prefsRepo.offlineMode) {
+            return
+        }
+        // TODO: this could possibly exhaust memory, ought have people w/ big libraries try it out
+        val networkTracks = mutableListOf<MediaItemTrack>()
+        withContext(Dispatchers.IO) {
+            try {
+                val libraryId = plexPrefs.library?.id ?: return@withContext
+                var tracksLeft = 1L
+                // Maximum number of pages of data we fetch. Failsafe in case of bad data from the
+                // server since we don't want infinite loops. This limits us to a maximum 1,000,000
+                // tracks for now
+                val maxIterations = 1000
+                var i = 0
+                while (tracksLeft > 0 && i < maxIterations) {
+                    val response = plexMediaService
+                        .retrieveTracksPaginated(libraryId, i * 100)
+                        .plexMediaContainer
+                    tracksLeft = response.totalSize - (response.offset + response.size)
+                    networkTracks.addAll(response.asTrackList())
+                    i++
+                }
+            } catch (t: Throwable) {
+                Timber.e("Failed to load tracks: $t")
+            }
+
+            val localTracks = trackDao.getAllTracksAsync()
+            val mergedTracks = mergeNetworkTracks(networkTracks, localTracks)
+            trackDao.insertAll(mergedTracks)
+        }
     }
 
     override suspend fun findTrackByTitle(title: String): MediaItemTrack? {

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/PlexService.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/PlexService.kt
@@ -45,6 +45,13 @@ interface PlexMediaService {
         @Path("libraryId") libraryId: String
     ): PlexMediaContainerWrapper
 
+    @GET("/library/sections/{libraryId}/all?type=$MEDIA_TYPE_ALBUM")
+    suspend fun retrieveAlbumPage(
+        @Path("libraryId") libraryId: String,
+        @Query("X-Plex-Container-Start") containerStart: Int = 0,
+        @Query("X-Plex-Container-Size") containerSize: Int = 100,
+    ): PlexMediaContainerWrapper
+
     @GET("/library/metadata/{trackId}")
     suspend fun retrieveChapterInfo(
         @Path("trackId") trackId: Int,
@@ -121,5 +128,12 @@ interface PlexMediaService {
     /** Loads all [MediaType.TRACK]s available in the server */
     @GET("/library/sections/{libraryId}/all?type=$MEDIA_TYPE_TRACK")
     suspend fun retrieveAllTracksInLibrary(@Path("libraryId") libraryId: String): PlexMediaContainerWrapper
+
+    @GET("/library/sections/{libraryId}/all?type=$MEDIA_TYPE_TRACK")
+    suspend fun retrieveTracksPaginated(
+        @Path("libraryId") libraryId: String,
+        @Query("X-Plex-Container-Start") containerStart: Int = 0,
+        @Query("X-Plex-Container-Size") containerSize: Int = 100,
+    ): PlexMediaContainerWrapper
 }
 

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/model/PlexMediaContainer.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/sources/plex/model/PlexMediaContainer.kt
@@ -17,7 +17,9 @@ data class PlexMediaContainer(
     val metadata: List<PlexDirectory> = emptyList(),
     val mediaProvider: MediaProvider? = null,
     val devices: List<PlexServer> = emptyList(),
-    val size: Long = 0
+    val size: Long = 0,
+    val totalSize: Long = 0,
+    val offset: Long = 0
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/home/HomeViewModel.kt
@@ -166,8 +166,8 @@ class HomeViewModel(
         viewModelScope.launch(Injector.get().unhandledExceptionHandler()) {
             try {
                 _isRefreshing.postValue(true)
-                bookRepository.refreshData()
-                trackRepository.refreshData()
+                bookRepository.refreshDataPaginated()
+                trackRepository.refreshDataPaginated()
             } catch (e: Throwable) {
                 _messageForUser.postEvent("Failed to refresh data: ${e.message}")
             } finally {

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/library/LibraryViewModel.kt
@@ -286,8 +286,8 @@ class LibraryViewModel(
         viewModelScope.launch(Injector.get().unhandledExceptionHandler()) {
             try {
                 _isRefreshing.postValue(true)
-                bookRepository.refreshData()
-                trackRepository.refreshData()
+                bookRepository.refreshDataPaginated()
+                trackRepository.refreshDataPaginated()
             } catch (e: Throwable) {
                 _messageForUser.postEvent("Failed to refresh data")
             } finally {


### PR DESCRIPTION
 - Fetch books/tracks in batches of 100 each, as opposed to fetching all in a single request.
 - This will prevent timeout errors for enormous libraries and for those on slow internet connections

#10 #2 