### PR TITLE
Show tooltip while sliding progress bar

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
@@ -3,15 +3,16 @@ package io.github.mattpvaughn.chronicle.features.currentlyplaying
 import android.content.Context
 import android.content.IntentFilter
 import android.os.Bundle
+import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.SeekBar
 import android.widget.Toast
 import android.widget.Toast.LENGTH_SHORT
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.google.android.material.slider.Slider
 import io.github.mattpvaughn.chronicle.application.MainActivity
 import io.github.mattpvaughn.chronicle.application.MainActivityViewModel.BottomSheetState.COLLAPSED
 import io.github.mattpvaughn.chronicle.data.model.Chapter
@@ -87,17 +88,24 @@ class CurrentlyPlayingFragment : Fragment() {
                 viewModel.jumpToChapter(chapter.startTimeOffset, chapter.trackId.toInt())
             }
         })
-        binding.chapterProgressSeekbar.setOnSeekBarChangeListener(object :
-            SeekBar.OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {}
-            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
 
-            override fun onStopTrackingTouch(seekBar: SeekBar?) {
-                if (seekBar != null) {
-                    viewModel.seekTo(seekBar.progress.toDouble() / seekBar.max)
-                }
+        binding.chapterProgressSeekbar.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+            override fun onStartTrackingTouch(slider: Slider) {
+                // Responds to when slider's touch event is being started
+            }
+
+            override fun onStopTrackingTouch(slider: Slider) {
+                // Responds to when slider's touch event is being stopped
+                viewModel.seekTo(slider.value.toDouble() / slider.valueTo)
             }
         })
+
+        binding.chapterProgressSeekbar.setLabelFormatter { value: Float ->
+            DateUtils.formatElapsedTime(
+                StringBuilder(),
+                value.toLong() / 1000
+            )
+        }
 
         viewModel.activeChapter.observe(viewLifecycleOwner) { chapter ->
             Timber.i("Updating current chapter: (${chapter.trackId}, ${chapter.discNumber}, ${chapter.index})")

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
@@ -91,11 +91,11 @@ class CurrentlyPlayingFragment : Fragment() {
 
         binding.chapterProgressSeekbar.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
             override fun onStartTrackingTouch(slider: Slider) {
-                // Responds to when slider's touch event is being started
+                viewModel.isSliding = true
             }
 
             override fun onStopTrackingTouch(slider: Slider) {
-                // Responds to when slider's touch event is being stopped
+                viewModel.isSliding = false
                 viewModel.seekTo(slider.value.toDouble() / slider.valueTo)
             }
         })

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
@@ -39,6 +39,8 @@ import io.github.mattpvaughn.chronicle.views.BottomSheetChooser.*
 import io.github.mattpvaughn.chronicle.views.BottomSheetChooser.BottomChooserState.Companion.EMPTY_BOTTOM_CHOOSER
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -150,6 +152,16 @@ class CurrentlyPlayingViewModel(
         )
     }
 
+    val chapterProgressForSlider = currentlyPlaying.chapter.combine(currentlyPlaying.track)
+    { chapter: Chapter, track: MediaItemTrack ->
+        track.progress - chapter.startTimeOffset
+    }.filter { !isSliding }.asLiveData(viewModelScope.coroutineContext)
+
+    val trackProgressForSlider = currentlyPlaying.track
+        .filter { !isSliding }
+        .map { it.progress }
+        .asLiveData(viewModelScope.coroutineContext)
+
     val chapterDuration = Transformations.map(currentChapter) {
         return@map it.endTimeOffset - it.startTimeOffset
     }
@@ -160,6 +172,8 @@ class CurrentlyPlayingViewModel(
             duration / 1000
         )
     }
+
+    var isSliding = false
 
     private var _isSleepTimerActive = MutableLiveData(false)
     val isSleepTimerActive: LiveData<Boolean>

--- a/app/src/main/res/layout/fragment_currently_playing.xml
+++ b/app/src/main/res/layout/fragment_currently_playing.xml
@@ -153,18 +153,24 @@
                         app:layout_constraintTop_toBottomOf="@+id/details_pause_play"
                         app:tint="@{viewModel.isSleepTimerActive() ? @color/iconActive : @color/icon}" />
 
-                    <SeekBar
+                    <com.google.android.material.slider.Slider
                         android:id="@+id/chapter_progress_seekbar"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="@dimen/margin_normal"
                         android:layout_marginTop="@dimen/currently_playing_seekbar_margin_top"
                         android:layout_marginRight="@dimen/margin_normal"
-                        android:max="@{(int) (viewModel.chapterDuration == 0L ? viewModel.currentTrack.duration : viewModel.chapterDuration ) }"
-                        android:progress="@{(int) (viewModel.chapterProgress == -1L ? viewModel.currentTrack.progress : viewModel.chapterProgress)}"
+                        android:value="@{(int) (viewModel.chapterProgress == -1L ? viewModel.currentTrack.progress : viewModel.chapterProgress)}"
+                        android:valueTo="@{(int) (viewModel.chapterDuration == 0L ? viewModel.currentTrack.duration : viewModel.chapterDuration ) }"
+                        app:labelStyle="@style/ProgressSliderTooltip"
                         app:layout_constraintLeft_toLeftOf="@id/left_gutter"
                         app:layout_constraintRight_toRightOf="@id/right_gutter"
-                        app:layout_constraintTop_toBottomOf="@id/progress" />
+                        app:layout_constraintTop_toBottomOf="@id/progress"
+                        app:thumbColor="@color/progressTintColor"
+                        app:thumbRadius="8dp"
+                        app:trackColorActive="@color/progressTintColor"
+                        app:trackColorInactive="@color/progressTrackTintColor"
+                        app:trackHeight="3dp" />
 
                     <TextView
                         android:id="@+id/progress"

--- a/app/src/main/res/layout/fragment_currently_playing.xml
+++ b/app/src/main/res/layout/fragment_currently_playing.xml
@@ -160,7 +160,7 @@
                         android:layout_marginLeft="@dimen/margin_normal"
                         android:layout_marginTop="@dimen/currently_playing_seekbar_margin_top"
                         android:layout_marginRight="@dimen/margin_normal"
-                        android:value="@{(int) (viewModel.chapterProgress == -1L ? viewModel.currentTrack.progress : viewModel.chapterProgress)}"
+                        android:value="@{(int) (viewModel.chapterProgressForSlider == -1L ? viewModel.trackProgressForSlider : viewModel.chapterProgressForSlider)}"
                         android:valueTo="@{(int) (viewModel.chapterDuration == 0L ? viewModel.currentTrack.duration : viewModel.chapterDuration ) }"
                         app:labelStyle="@style/ProgressSliderTooltip"
                         app:layout_constraintLeft_toLeftOf="@id/left_gutter"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -85,6 +85,24 @@
         <item name="searchViewStyle">@style/SearchViewTheme</item>
     </style>
 
+    <!-- Progress Slider -->
+    <style name="ProgressSliderTooltip" parent="Widget.MaterialComponents.Tooltip">
+        <item name="backgroundTint">@color/colorAccent</item>
+        <item name="android:textAppearance">@style/ProgressSliderTextAppearance</item>
+
+        <item name="android:background">@color/colorAccent</item>
+        <item name="fontWeight">400</item>
+        <item name="fontFamily">@font/lato</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+    </style>
+
+    <style name="ProgressSliderTextAppearance" parent="@style/TextAppearance.MaterialComponents.Tooltip">
+        <item name="android:textColor">@android:color/white</item>
+        <item name="fontFamily">@font/lato</item>
+        <item name="fontWeight">600</item>
+    </style>
+
     <!-- Bottom Navigation -->
     <style name="Widget.BottomNavigationView" parent="Widget.Design.BottomNavigationView">
         <item name="fontFamily">@font/lato_bold</item>


### PR DESCRIPTION
I replaced SeekBar with Material Slider, which comes with an integrated value label. Resolves #37 

There is one small issue that already occurs with the current implementation of SeekBar. The progress is continuously updated and if the slider is touched but not moving it sometimes jumps to the new position and returns after moving again.  With onStartTrackingTouch & onStopTrackingTouch I could add a variable like "isSliding" but I don't know where it can be used to prevent updating the progress, especially when the chapter_progress TextView should continue to be updated.
