### PR TITLE
New speed chooser ui

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/SharedPreferencesPrefsRepo.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/SharedPreferencesPrefsRepo.kt
@@ -29,6 +29,7 @@ import io.github.mattpvaughn.chronicle.data.local.PrefsRepo.Companion.VIEW_STYLE
 import io.github.mattpvaughn.chronicle.data.local.PrefsRepo.Companion.VIEW_STYLE_COVER_GRID
 import io.github.mattpvaughn.chronicle.data.model.Audiobook
 import io.github.mattpvaughn.chronicle.data.sources.plex.model.MediaType
+import io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel.Companion.PLAYBACK_SPEED_DEFAULT
 import io.github.mattpvaughn.chronicle.injection.components.AppComponent
 import java.io.File
 import javax.inject.Inject
@@ -215,7 +216,7 @@ class SharedPreferencesPrefsRepo @Inject constructor(private val sharedPreferenc
         get() = sharedPreferences.getLong(KEY_JUMP_BACKWARD_SECONDS, defaultJumpBackwardSeconds)
         set(value) = sharedPreferences.edit().putLong(KEY_JUMP_BACKWARD_SECONDS, value).apply()
 
-    private val defaultPlaybackSpeed = 1.0f
+    private val defaultPlaybackSpeed = PLAYBACK_SPEED_DEFAULT
     override var playbackSpeed: Float
         get() = sharedPreferences.getFloat(KEY_PLAYBACK_SPEED, defaultPlaybackSpeed)
         set(value) = sharedPreferences.edit().putFloat(KEY_PLAYBACK_SPEED, value).apply()

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/bookdetails/AudiobookDetailsBindingAdapters.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/bookdetails/AudiobookDetailsBindingAdapters.kt
@@ -8,31 +8,9 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
-import io.github.mattpvaughn.chronicle.R
 import io.github.mattpvaughn.chronicle.data.model.Chapter
-import io.github.mattpvaughn.chronicle.views.BottomSheetChooser.FormattableString.ResourceString
-import io.github.mattpvaughn.chronicle.views.getString
 import okhttp3.internal.toHexString
 import timber.log.Timber
-
-@BindingAdapter("playbackSpeed")
-fun bindPlaybackSpeed(imageView: ImageView, speed: Float) {
-    Timber.i("Playback speed changed! $speed")
-    imageView.contentDescription = imageView.resources.getString(
-        ResourceString(R.string.playback_speed_desc, listOf(speed.toString()))
-    )
-    when (speed) {
-        0.5f -> imageView.setImageResource(R.drawable.ic_speed_up_0_5x)
-        0.7f -> imageView.setImageResource(R.drawable.ic_speed_up_0_7x)
-        1.0f -> imageView.setImageResource(R.drawable.ic_speed_up_1_0x)
-        1.2f -> imageView.setImageResource(R.drawable.ic_speed_up_1_2x)
-        1.5f -> imageView.setImageResource(R.drawable.ic_speed_up_1_5x)
-        1.7f -> imageView.setImageResource(R.drawable.ic_speed_up_1_7x)
-        2.0f -> imageView.setImageResource(R.drawable.ic_speed_up_2_0x)
-        3.0f -> imageView.setImageResource(R.drawable.ic_speed_up_3_0x)
-        else -> throw Error("Illegal playback speed set: $speed")
-    }
-}
 
 @BindingAdapter("chapterList")
 fun bindChapterList(recyclerView: RecyclerView, chapters: List<Chapter>?) {

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
@@ -22,6 +22,7 @@ import io.github.mattpvaughn.chronicle.features.bookdetails.ChapterListAdapter
 import io.github.mattpvaughn.chronicle.features.bookdetails.TrackClickListener
 import io.github.mattpvaughn.chronicle.features.player.SleepTimer
 import io.github.mattpvaughn.chronicle.util.observeEvent
+import io.github.mattpvaughn.chronicle.views.ModalBottomSheetSpeedChooser
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import timber.log.Timber
 import javax.inject.Inject
@@ -66,6 +67,8 @@ class CurrentlyPlayingFragment : Fragment() {
         localBroadcastManager.unregisterReceiver(viewModel.onUpdateSleepTimer)
         super.onStop()
     }
+
+    private val modalBottomSheetSpeedChooser = ModalBottomSheetSpeedChooser()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -120,6 +123,19 @@ class CurrentlyPlayingFragment : Fragment() {
 
         binding.detailsToolbar.setNavigationOnClickListener {
             currentlyPlayingInterface.setBottomSheetState(COLLAPSED)
+        }
+
+        viewModel.showModalBottomSheetSpeedChooser.observe(viewLifecycleOwner) { visible ->
+            if(visible) modalBottomSheetSpeedChooser.show(childFragmentManager, ModalBottomSheetSpeedChooser.TAG)
+        }
+
+        viewModel.speed.observe(viewLifecycleOwner) { value ->
+            Timber.i("viewModel.speed.observe → $value")
+            // todo: remove → only for debugging
+        }
+        viewModel.playbackSpeedString.observe(viewLifecycleOwner) { value ->
+            Timber.i("viewModel.playbackSpeedString.observe → $value")
+            // todo: remove → only for debugging
         }
 
         return binding.root

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingFragment.kt
@@ -68,12 +68,10 @@ class CurrentlyPlayingFragment : Fragment() {
         super.onStop()
     }
 
-    private val modalBottomSheetSpeedChooser = ModalBottomSheetSpeedChooser()
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
 
         // Activity and context are non-null on view creation. This informs lint about that
         val binding = FragmentCurrentlyPlayingBinding.inflate(inflater, container, false)
@@ -125,17 +123,14 @@ class CurrentlyPlayingFragment : Fragment() {
             currentlyPlayingInterface.setBottomSheetState(COLLAPSED)
         }
 
-        viewModel.showModalBottomSheetSpeedChooser.observe(viewLifecycleOwner) { visible ->
-            if(visible) modalBottomSheetSpeedChooser.show(childFragmentManager, ModalBottomSheetSpeedChooser.TAG)
-        }
-
-        viewModel.speed.observe(viewLifecycleOwner) { value ->
-            Timber.i("viewModel.speed.observe → $value")
-            // todo: remove → only for debugging
-        }
-        viewModel.playbackSpeedString.observe(viewLifecycleOwner) { value ->
-            Timber.i("viewModel.playbackSpeedString.observe → $value")
-            // todo: remove → only for debugging
+        viewModel.showModalBottomSheetSpeedChooser.observe(viewLifecycleOwner) { eventShowChooser ->
+            if (!eventShowChooser.hasBeenHandled) {
+                ModalBottomSheetSpeedChooser().show(
+                    childFragmentManager,
+                    ModalBottomSheetSpeedChooser.TAG
+                )
+                eventShowChooser.getContentIfNotHandled()
+            }
         }
 
         return binding.root

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
@@ -11,6 +11,7 @@ import android.support.v4.media.session.PlaybackStateCompat.STATE_PAUSED
 import android.text.format.DateUtils
 import android.view.Gravity
 import android.widget.Toast
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.*
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.github.michaelbull.result.Ok
@@ -37,6 +38,7 @@ import io.github.mattpvaughn.chronicle.features.player.SleepTimer.SleepTimerActi
 import io.github.mattpvaughn.chronicle.util.*
 import io.github.mattpvaughn.chronicle.views.BottomSheetChooser.*
 import io.github.mattpvaughn.chronicle.views.BottomSheetChooser.BottomChooserState.Companion.EMPTY_BOTTOM_CHOOSER
+import io.github.mattpvaughn.chronicle.views.ModalBottomSheetSpeedChooser
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
@@ -53,8 +55,9 @@ class CurrentlyPlayingViewModel(
     private val mediaServiceConnection: MediaServiceConnection,
     private val prefsRepo: PrefsRepo,
     private val plexConfig: PlexConfig,
-    private val currentlyPlaying: CurrentlyPlaying
-) : ViewModel() {
+    private val currentlyPlaying: CurrentlyPlaying,
+    private val fragmentManager: FragmentManager
+    ) : ViewModel() {
 
     @Suppress("UNCHECKED_CAST")
     class Factory @Inject constructor(
@@ -64,8 +67,9 @@ class CurrentlyPlayingViewModel(
         private val mediaServiceConnection: MediaServiceConnection,
         private val prefsRepo: PrefsRepo,
         private val plexConfig: PlexConfig,
-        private val currentlyPlaying: CurrentlyPlaying
-    ) : ViewModelProvider.Factory {
+        private val currentlyPlaying: CurrentlyPlaying,
+        private val fragmentManager: FragmentManager
+        ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(CurrentlyPlayingViewModel::class.java)) {
                 return CurrentlyPlayingViewModel(
@@ -75,7 +79,8 @@ class CurrentlyPlayingViewModel(
                     mediaServiceConnection,
                     prefsRepo,
                     plexConfig,
-                    currentlyPlaying
+                    currentlyPlaying,
+                    fragmentManager
                 ) as T
             } else {
                 throw IllegalArgumentException("Incorrect class type provided")
@@ -129,6 +134,10 @@ class CurrentlyPlayingViewModel(
     private var _speed = MutableLiveData(prefsRepo.playbackSpeed)
     val speed: LiveData<Float>
         get() = _speed
+
+    val playbackSpeedString = Transformations.map(speed) { speed ->
+        return@map String.format("%.2f", speed) + "x"
+    }
 
     val activeTrackId: LiveData<Int> =
         Transformations.map(mediaServiceConnection.nowPlaying) { metadata ->
@@ -246,6 +255,8 @@ class CurrentlyPlayingViewModel(
     val bottomChooserState: LiveData<BottomChooserState>
         get() = _bottomChooserState
 
+    private val modalBottomSheetSpeedChooser = ModalBottomSheetSpeedChooser()
+
     private var _sleepTimerChooserState = MutableLiveData(EMPTY_BOTTOM_CHOOSER)
     val sleepTimerChooserState: LiveData<BottomChooserState>
         get() = _sleepTimerChooserState
@@ -260,7 +271,10 @@ class CurrentlyPlayingViewModel(
 
     private val prefsChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         when (key) {
-            PrefsRepo.KEY_PLAYBACK_SPEED -> _speed.postValue(prefsRepo.playbackSpeed)
+            PrefsRepo.KEY_PLAYBACK_SPEED -> _speed.postValue(
+                if(prefsRepo.playbackSpeed < PLAYBACK_SPEED_MIN || prefsRepo.playbackSpeed > PLAYBACK_SPEED_MAX) PLAYBACK_SPEED_DEFAULT
+                else prefsRepo.playbackSpeed
+            )
             PrefsRepo.KEY_JUMP_FORWARD_SECONDS -> _jumpForwardsIcon.value = makeJumpForwardsIcon()
             PrefsRepo.KEY_JUMP_BACKWARD_SECONDS -> _jumpBackwardsIcon.value = makeJumpBackwardsIcon()
         }
@@ -616,42 +630,19 @@ class CurrentlyPlayingViewModel(
         )
     }
 
-    fun showSpeedChooser() {
+    fun showPlaybackSpeedChooser() {
         if (!prefsRepo.isPremium) {
             _showUserMessage.postEvent("Error: variable playback speed is a premium feature")
             return
         }
-        showOptionsMenu(
-            title = FormattableString.from(R.string.playback_speed_title),
-            options = listOf(
-                FormattableString.from(R.string.playback_speed_0_5x),
-                FormattableString.from(R.string.playback_speed_0_7x),
-                FormattableString.from(R.string.playback_speed_1_0x),
-                FormattableString.from(R.string.playback_speed_1_2x),
-                FormattableString.from(R.string.playback_speed_1_5x),
-                FormattableString.from(R.string.playback_speed_1_7x),
-                FormattableString.from(R.string.playback_speed_2_0x),
-                FormattableString.from(R.string.playback_speed_3_0x)
-            ),
-            listener = object : BottomChooserItemListener() {
-                override fun onItemClicked(formattableString: FormattableString) {
-                    check(formattableString is FormattableString.ResourceString)
+        modalBottomSheetSpeedChooser.show(fragmentManager, ModalBottomSheetSpeedChooser.TAG)
+    }
 
-                    prefsRepo.playbackSpeed = when (formattableString.stringRes) {
-                        R.string.playback_speed_0_5x -> 0.5f
-                        R.string.playback_speed_0_7x -> 0.7f
-                        R.string.playback_speed_1_0x -> 1.0f
-                        R.string.playback_speed_1_2x -> 1.2f
-                        R.string.playback_speed_1_5x -> 1.5f
-                        R.string.playback_speed_1_7x -> 1.7f
-                        R.string.playback_speed_2_0x -> 2.0f
-                        R.string.playback_speed_3_0x -> 3.0f
-                        else -> throw NoWhenBranchMatchedException("Unknown playback speed selected")
-                    }
-                    hideOptionsMenu()
-                }
-            }
-        )
+    fun updatePlaybackSpeed(value : Float) {
+        Timber.d("updatePlaybackSpeed → $value")
+        prefsRepo.playbackSpeed =
+            if(value < PLAYBACK_SPEED_MIN || value > PLAYBACK_SPEED_MAX) PLAYBACK_SPEED_DEFAULT
+            else value
     }
 
     private fun hideSleepTimerChooser() {
@@ -680,7 +671,6 @@ class CurrentlyPlayingViewModel(
             )
         )
     }
-
 
     val onUpdateSleepTimer = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -736,5 +726,12 @@ class CurrentlyPlayingViewModel(
                 mediaServiceConnection.transportControls?.seekTo(offset)
             }
         }
+    }
+
+    companion object {
+        /** Minimal and maximal allowed playback speed. */
+        const val PLAYBACK_SPEED_MIN = 0.5f
+        const val PLAYBACK_SPEED_DEFAULT = 1.0f
+        const val PLAYBACK_SPEED_MAX = 3.0f
     }
 }

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/AudiobookMediaSessionCallback.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/AudiobookMediaSessionCallback.kt
@@ -136,11 +136,6 @@ class AudiobookMediaSessionCallback @Inject constructor(
         currentPlayer.seekRelative(trackListStateManager, prefsRepo.jumpBackwardSeconds * MILLIS_PER_SECOND * -1)
     }
 
-    private fun changeSpeed() {
-        changeSpeed(trackListStateManager, mediaSessionConnector, prefsRepo, currentlyPlaying, progressUpdater)
-        Timber.i("New Speed: %s", prefsRepo.playbackSpeed)
-    }
-
     override fun onMediaButtonEvent(mediaButtonEvent: Intent?): Boolean {
         if (mediaButtonEvent == null) {
             return false
@@ -219,7 +214,6 @@ class AudiobookMediaSessionCallback @Inject constructor(
             }
             SKIP_FORWARDS_STRING -> skipForwards()
             SKIP_BACKWARDS_STRING -> skipBackwards()
-            CHANGE_PLAYBACK_SPEED -> changeSpeed()
             SKIP_TO_NEXT_STRING -> skipToNext()
             SKIP_TO_PREVIOUS_STRING -> skipToPrevious()
         }

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/CustomActions.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/CustomActions.kt
@@ -10,20 +10,20 @@ import android.view.KeyEvent.KEYCODE_MEDIA_NEXT
 import android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS
 import com.google.android.exoplayer2.ControlDispatcher
 import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector.CustomActionProvider
 import io.github.mattpvaughn.chronicle.R
 import io.github.mattpvaughn.chronicle.application.MILLIS_PER_SECOND
 import io.github.mattpvaughn.chronicle.data.local.PrefsRepo
 import io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlaying
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 
 /**
  * The custom actions provided to [MediaSessionConnector.setCustomActionProviders()] for the app
  */
+@ExperimentalCoroutinesApi
 fun makeCustomActionProviders(
     trackListStateManager: TrackListStateManager,
-    mediaSessionConnector: MediaSessionConnector,
     prefsRepo: PrefsRepo,
     currentlyPlaying: CurrentlyPlaying,
     progressUpdater: ProgressUpdater
@@ -41,38 +41,6 @@ fun makeCustomActionProviders(
         SimpleCustomActionProvider(SKIP_TO_PREVIOUS) { player: Player, _: String, _: Bundle? ->
             player.skipToPrevious(trackListStateManager, currentlyPlaying, progressUpdater)
       },
-        SimpleCustomActionProvider(makeChangeSpeed(prefsRepo)) { player: Player, _: String, _: Bundle? ->
-            changeSpeed(trackListStateManager, mediaSessionConnector, prefsRepo, currentlyPlaying, progressUpdater)
-        }
-    )
-}
-
-fun changeSpeed(
-    trackListStateManager: TrackListStateManager,
-    mediaSessionConnector: MediaSessionConnector,
-    prefsRepo: PrefsRepo,
-    currentlyPlaying: CurrentlyPlaying,
-    progressUpdater: ProgressUpdater
-) {
-    when (prefsRepo.playbackSpeed) {
-        0.5f -> prefsRepo.playbackSpeed = 0.7f
-        0.7f -> prefsRepo.playbackSpeed = 1.0f
-        1.0f -> prefsRepo.playbackSpeed = 1.2f
-        1.2f -> prefsRepo.playbackSpeed = 1.5f
-        1.5f -> prefsRepo.playbackSpeed = 1.7f
-        1.7f -> prefsRepo.playbackSpeed = 2.0f
-        2.0f -> prefsRepo.playbackSpeed = 3.0f
-        3.0f -> prefsRepo.playbackSpeed = 0.5f
-        else -> prefsRepo.playbackSpeed = 1.0f
-    }
-    mediaSessionConnector.setCustomActionProviders(
-        *makeCustomActionProviders(
-            trackListStateManager,
-            mediaSessionConnector,
-            prefsRepo,
-            currentlyPlaying,
-            progressUpdater
-        )
     )
 }
 
@@ -131,29 +99,6 @@ fun makeSkipBackward(
     return PlaybackStateCompat.CustomAction.Builder(
         SKIP_BACKWARDS_STRING,
         SKIP_BACKWARDS_STRING,
-        drawable
-    ).build()
-}
-
-const val CHANGE_PLAYBACK_SPEED = "Change Speed"
-
-fun makeChangeSpeed(
-    prefsRepo: PrefsRepo
-): PlaybackStateCompat.CustomAction {
-    val drawable: Int = when (prefsRepo.playbackSpeed) {
-        0.5f -> R.drawable.ic_speed_up_0_5x
-        0.7f -> R.drawable.ic_speed_up_0_7x
-        1.0f -> R.drawable.ic_speed_up_1_0x
-        1.2f -> R.drawable.ic_speed_up_1_2x
-        1.5f -> R.drawable.ic_speed_up_1_5x
-        1.7f -> R.drawable.ic_speed_up_1_7x
-        2.0f -> R.drawable.ic_speed_up_2_0x
-        3.0f -> R.drawable.ic_speed_up_3_0x
-        else -> R.drawable.ic_speed_up_1_0x
-    }
-    return PlaybackStateCompat.CustomAction.Builder(
-        CHANGE_PLAYBACK_SPEED,
-        CHANGE_PLAYBACK_SPEED,
         drawable
     ).build()
 }

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/MediaPlayerService.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/player/MediaPlayerService.kt
@@ -204,7 +204,6 @@ class MediaPlayerService : MediaBrowserServiceCompat(), ForegroundServiceControl
         mediaSessionConnector.setCustomActionProviders(
             *makeCustomActionProviders(
                 trackListManager,
-                mediaSessionConnector,
                 prefsRepo,
                 currentlyPlaying,
                 progressUpdater

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/injection/components/ActivityComponent.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/injection/components/ActivityComponent.kt
@@ -17,6 +17,7 @@ import io.github.mattpvaughn.chronicle.features.settings.SettingsViewModel
 import io.github.mattpvaughn.chronicle.injection.modules.ActivityModule
 import io.github.mattpvaughn.chronicle.injection.scopes.ActivityScope
 import io.github.mattpvaughn.chronicle.navigation.Navigator
+import io.github.mattpvaughn.chronicle.views.ModalBottomSheetSpeedChooser
 
 @ActivityScope
 @Component(dependencies = [AppComponent::class], modules = [ActivityModule::class])
@@ -37,5 +38,6 @@ interface ActivityComponent {
     fun inject(homeFragment: HomeFragment)
     fun inject(settingsFragment: SettingsFragment)
     fun inject(currentlyPlayingFragment: CurrentlyPlayingFragment)
+    fun inject(modalBottomSheetSpeedChooser: ModalBottomSheetSpeedChooser)
 }
 

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/util/SharedPreferencesExt.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/util/SharedPreferencesExt.kt
@@ -52,3 +52,28 @@ class StringPreferenceLiveData(
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(prefListener)
     }
 }
+
+/** Exposes a string in [SharedPreferences] as [LiveData] */
+class FloatPreferenceLiveData(
+    private val key: String,
+    private val defaultValue: Float,
+    private val sharedPreferences: SharedPreferences
+) : LiveData<Float>() {
+    private val prefListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
+            if (key == this@FloatPreferenceLiveData.key) {
+                sharedPreferences?.getFloat(key, defaultValue)?.let {
+                    value = it
+                }
+            }
+        }
+
+    override fun onActive() {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(prefListener)
+        value = sharedPreferences.getFloat(key, defaultValue)
+    }
+
+    override fun onInactive() {
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(prefListener)
+    }
+}

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/views/ModalBottomSheetSpeedChooser.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/views/ModalBottomSheetSpeedChooser.kt
@@ -1,18 +1,18 @@
 package io.github.mattpvaughn.chronicle.views
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.slider.Slider
 import io.github.mattpvaughn.chronicle.application.MainActivity
+import io.github.mattpvaughn.chronicle.data.local.PrefsRepo
 import io.github.mattpvaughn.chronicle.databinding.ModalBottomSheetSpeedChooserBinding
-import io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import timber.log.Timber
 import javax.inject.Inject
@@ -20,12 +20,10 @@ import javax.inject.Inject
 @ExperimentalCoroutinesApi
 class ModalBottomSheetSpeedChooser : BottomSheetDialogFragment() {
 
-    @Inject
-    lateinit var viewModelFactory: CurrentlyPlayingViewModel.Factory
+    private var prefsListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
 
-    private val viewModel: CurrentlyPlayingViewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get(CurrentlyPlayingViewModel::class.java)
-    }
+    @Inject
+    lateinit var prefs: PrefsRepo
 
     override fun onAttach(context: Context) {
         (requireActivity() as MainActivity).activityComponent!!.inject(this)
@@ -36,16 +34,16 @@ class ModalBottomSheetSpeedChooser : BottomSheetDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
 
         val binding = ModalBottomSheetSpeedChooserBinding.inflate(inflater, container, false)
-        binding.viewModel = viewModel
+        binding.speed = prefs.playbackSpeed
 
         binding.speedSlider.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
             override fun onStartTrackingTouch(slider: Slider) {}
 
             override fun onStopTrackingTouch(slider: Slider) {
-                viewModel.updatePlaybackSpeed(slider.value)
+                prefs.playbackSpeed = slider.value
             }
         })
 
@@ -56,22 +54,34 @@ class ModalBottomSheetSpeedChooser : BottomSheetDialogFragment() {
         binding.speedPresets.setOnCheckedStateChangeListener { group: ChipGroup, checkedId ->
             Timber.w("setOnCheckedStateChangeListener: $group | $checkedId")
             val speed = when (group.findViewById<Chip>(checkedId.first()).tag as String) {
+                // Note: tag="@string/xxx" ends up turning into a string and
+                // can't be reference as an R.id.xxx
                 "1.0x" -> 1.0f
                 "1.2x" -> 1.2f
                 "1.5x" -> 1.5f
                 "2.0x" -> 2.0f
-                // R.string.playback_speed_1_0x -> 1.0f  (not sure why this gives an error)
-                // R.string.playback_speed_1_2x -> 1.2f
-                // R.string.playback_speed_1_5x -> 1.5f
-                // R.string.playback_speed_2_0x -> 2.0f
                 else -> 1.0f
             }
-            viewModel.updatePlaybackSpeed(speed)
+            prefs.playbackSpeed = speed
             binding.speedSlider.value = speed
         }
 
-        return binding.root
+        prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == PrefsRepo.KEY_PLAYBACK_SPEED) {
+                binding.speed = prefs.playbackSpeed
+            }
+        }.apply {
+            prefs.registerPrefsListener(this)
+        }
 
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        prefsListener?.let {
+            prefs.unregisterPrefsListener(it)
+        }
     }
 
     companion object {

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/views/ModalBottomSheetSpeedChooser.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/views/ModalBottomSheetSpeedChooser.kt
@@ -1,0 +1,80 @@
+package io.github.mattpvaughn.chronicle.views
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.google.android.material.slider.Slider
+import io.github.mattpvaughn.chronicle.application.MainActivity
+import io.github.mattpvaughn.chronicle.databinding.ModalBottomSheetSpeedChooserBinding
+import io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import timber.log.Timber
+import javax.inject.Inject
+
+@ExperimentalCoroutinesApi
+class ModalBottomSheetSpeedChooser : BottomSheetDialogFragment() {
+
+    @Inject
+    lateinit var viewModelFactory: CurrentlyPlayingViewModel.Factory
+
+    private val viewModel: CurrentlyPlayingViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory).get(CurrentlyPlayingViewModel::class.java)
+    }
+
+    override fun onAttach(context: Context) {
+        (requireActivity() as MainActivity).activityComponent!!.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+
+        val binding = ModalBottomSheetSpeedChooserBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
+
+        binding.speedSlider.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+            override fun onStartTrackingTouch(slider: Slider) {}
+
+            override fun onStopTrackingTouch(slider: Slider) {
+                viewModel.updatePlaybackSpeed(slider.value)
+            }
+        })
+
+        binding.speedSlider.setLabelFormatter { value: Float ->
+            String.format("%.2f", value) + "x"
+        }
+
+        binding.speedPresets.setOnCheckedStateChangeListener { group: ChipGroup, checkedId ->
+            Timber.w("setOnCheckedStateChangeListener: $group | $checkedId")
+            val speed = when (group.findViewById<Chip>(checkedId.first()).tag as String) {
+                "1.0x" -> 1.0f
+                "1.2x" -> 1.2f
+                "1.5x" -> 1.5f
+                "2.0x" -> 2.0f
+                // R.string.playback_speed_1_0x -> 1.0f  (not sure why this gives an error)
+                // R.string.playback_speed_1_2x -> 1.2f
+                // R.string.playback_speed_1_5x -> 1.5f
+                // R.string.playback_speed_2_0x -> 2.0f
+                else -> 1.0f
+            }
+            viewModel.updatePlaybackSpeed(speed)
+            binding.speedSlider.value = speed
+        }
+
+        return binding.root
+
+    }
+
+    companion object {
+        const val TAG = "ModalBottomSheetSpeedChooser"
+    }
+}

--- a/app/src/main/res/color/chip_same_background_color.xml
+++ b/app/src/main/res/color/chip_same_background_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/iconDisabled" android:state_checked="true" />
+    <item android:color="@color/iconDisabled" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/layout/fragment_currently_playing.xml
+++ b/app/src/main/res/layout/fragment_currently_playing.xml
@@ -118,22 +118,23 @@
                         app:layout_constraintRight_toRightOf="@id/right_gutter"
                         app:layout_constraintTop_toTopOf="@id/details_pause_play" />
 
-
-                    <ImageView
+                    <Button
                         android:id="@+id/change_speed_button"
-                        android:layout_width="@dimen/list_icon_size"
-                        android:layout_height="@dimen/list_icon_size"
-                        android:layout_margin="@dimen/margin_normal"
-                        android:background="?android:attr/selectableItemBackgroundBorderless"
+                        style="@style/Widget.AppCompat.Button.Borderless"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:clickable="true"
                         android:focusable="true"
-                        android:onClick="@{() -> viewModel.showSpeedChooser()}"
+                        android:onClick="@{() -> viewModel.showPlaybackSpeedChooser()}"
+                        android:text="@{viewModel.playbackSpeedString}"
+                        android:textAllCaps="false"
+                        android:textColor="@color/icon"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="@+id/sleep_timer_button"
                         app:layout_constraintEnd_toStartOf="@+id/sleep_timer_button"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/details_pause_play"
-                        app:playbackSpeed="@{viewModel.speed}"
-                        tools:ignore="ContentDescription"
-                        tools:src="@drawable/ic_speed_up_1_0x" />
+                        app:layout_constraintTop_toTopOf="@+id/sleep_timer_button" />
 
                     <ImageView
                         android:id="@+id/sleep_timer_button"

--- a/app/src/main/res/layout/modal_bottom_sheet_speed_chooser.xml
+++ b/app/src/main/res/layout/modal_bottom_sheet_speed_chooser.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel" />
+
+        <import type="android.view.View" />
+    </data>
+
+
+
+        <LinearLayout
+            android:id="@+id/bottom_sheet_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/bottom_sheet_handle"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_handle_height"
+                android:background="@color/colorPrimary"
+                app:boxCornerRadiusTopEnd="@dimen/audiobook_item_radius"
+                app:boxCornerRadiusTopStart="@dimen/audiobook_item_radius">
+
+                <TextView
+                    style="@style/TextAppearance.Subtitle.Settings"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="@dimen/screen_horizontal_padding"
+                    android:text="@string/playback_speed_title"
+                    android:textColor="@color/textPrimary"
+                    android:textSize="16sp" />
+
+            </FrameLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/colorPrimaryDark">
+
+                <TextView
+                    android:id="@+id/speed_min"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="32dp"
+                    android:text="@string/playback_speed_min"
+                    app:layout_constraintBottom_toBottomOf="@+id/speed_slider"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/speed_slider" />
+
+                <TextView
+                    android:id="@+id/speed_max"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_weight="1"
+                    android:text="@string/playback_speed_max"
+                    app:layout_constraintBottom_toBottomOf="@+id/speed_slider"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/speed_slider" />
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/speed_presets"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="24dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/speed_slider"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/speed_1.0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tag="@string/playback_speed_1_0x"
+                        android:text="@string/playback_speed_1_0x"
+                        android:value="1.0f"
+                        app:chipBackgroundColor="@color/chip_same_background_color" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/speed_1.2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tag="@string/playback_speed_1_2x"
+                        android:text="@string/playback_speed_1_2x"
+                        android:value="1.2f"
+                        app:chipBackgroundColor="@color/chip_same_background_color" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/speed_1.5"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tag="@string/playback_speed_1_5x"
+                        android:text="@string/playback_speed_1_5x"
+                        android:value="1.5f"
+                        app:chipBackgroundColor="@color/chip_same_background_color" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/speed_2.0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tag="@string/playback_speed_2_0x"
+                        android:text="@string/playback_speed_2_0x"
+                        android:value="2.0f"
+                        app:chipBackgroundColor="@color/chip_same_background_color" />
+
+                </com.google.android.material.chip.ChipGroup>
+
+                <com.google.android.material.slider.Slider
+                    android:id="@+id/speed_slider"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:stepSize="0.05"
+                    android:value="@{viewModel.speed}"
+                    android:valueFrom="@{viewModel.PLAYBACK_SPEED_MIN}"
+                    android:valueTo="@{viewModel.PLAYBACK_SPEED_MAX}"
+                    app:labelBehavior="visible"
+                    app:labelStyle="@style/ProgressSliderTooltip"
+                    app:layout_constraintEnd_toStartOf="@id/speed_max"
+                    app:layout_constraintStart_toEndOf="@+id/speed_min"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:thumbColor="@color/progressTintColor"
+                    app:thumbRadius="8dp"
+                    app:tickVisible="false"
+                    app:trackColorActive="@color/progressTintColor"
+                    app:trackColorInactive="@color/progressTrackTintColor"
+                    app:trackHeight="3dp" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+        </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/modal_bottom_sheet_speed_chooser.xml
+++ b/app/src/main/res/layout/modal_bottom_sheet_speed_chooser.xml
@@ -3,14 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable
-            name="viewModel"
-            type="io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel" />
-
+        <variable name="speed" type="Float" />
         <import type="android.view.View" />
+        <import type="io.github.mattpvaughn.chronicle.features.currentlyplaying.CurrentlyPlayingViewModel" />
     </data>
-
-
 
         <LinearLayout
             android:id="@+id/bottom_sheet_container"
@@ -123,9 +119,9 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:stepSize="0.05"
-                    android:value="@{viewModel.speed}"
-                    android:valueFrom="@{viewModel.PLAYBACK_SPEED_MIN}"
-                    android:valueTo="@{viewModel.PLAYBACK_SPEED_MAX}"
+                    android:value="@{speed}"
+                    android:valueFrom="@{CurrentlyPlayingViewModel.PLAYBACK_SPEED_MIN}"
+                    android:valueTo="@{CurrentlyPlayingViewModel.PLAYBACK_SPEED_MAX}"
                     app:labelBehavior="visible"
                     app:labelStyle="@style/ProgressSliderTooltip"
                     app:layout_constraintEnd_toStartOf="@id/speed_max"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,15 +152,13 @@
 
     <!-- Speed chooser -->
     <string name="playback_speed_desc">Playback speed: %1$s times normal speed</string>
-    <string name="playback_speed_title">Playback speed</string>
-    <string name="playback_speed_0_5x">0.5x</string>
-    <string name="playback_speed_0_7x">0.7x</string>
+    <string name="playback_speed_title">Choose playback speed</string>
+    <string name="playback_speed_min">0.5x</string>
     <string name="playback_speed_1_0x">1.0x</string>
     <string name="playback_speed_1_2x">1.2x</string>
     <string name="playback_speed_1_5x">1.5x</string>
-    <string name="playback_speed_1_7x">1.7x</string>
     <string name="playback_speed_2_0x">2.0x</string>
-    <string name="playback_speed_3_0x">3.0x</string>
+    <string name="playback_speed_max">3.0x</string>
 
     <!-- Sleep timer-->
     <string name="sleep_timer">Sleep timer</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -106,6 +106,7 @@
     <!-- Bottom Navigation -->
     <style name="Widget.BottomNavigationView" parent="Widget.Design.BottomNavigationView">
         <item name="fontFamily">@font/lato_bold</item>
+        <item name="android:minHeight">0dp</item> // Fix for BottomNavigationView label above icon → https://stackoverflow.com/questions/70773346/bottomnavigationview-shows-label-over-icon
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         archLifecycleVersion = "1.1.1"
         gradleVersion = '7.0.2'
         supportlibVersion = '1.2.0'
-        materialLibVersion = '1.3.0'
+        materialLibVersion = '1.6.0-beta01' // todo: permanent visible slider label is available from 1.6 (currently in beta) → https://github.com/material-components/material-components-android/releases
         retrofitVersion = "2.9.0"
         moshiKotlinVersion = '1.13.0'
         okhttpVersion = '4.9.1'


### PR DESCRIPTION
This PR is a complete redesign of the current speed chooser. Instead of selecting options from a given list the user can now choose a custom playback speed between 0.5 and 3.0 in 0.05 steps with a slider.

![Screenshot_20220330-175956_2](https://user-images.githubusercontent.com/42645195/160882178-24e43a2e-b24a-4902-a365-afed309ec96d.jpg)
 
During testing I received some leak notifications, but I am not sure if this was caused by this PR. It should definitely be thoroughly checked and tested. Furthermore I noticed that sometimes the slider value is stuck and does not get updated. The actual playback speed and the button in the player however are working as expected. 

One thing to mention is that the current implementation relies on materialLibVersion = '1.6.0-beta01' which allows to show the slider label all the time and not only when touched (app:labelBehavior="visible"). If this dependency is not accepted, we can change that and start with the progress only visible while sliding and change it as soon as 1.6.0 is published as stable.

Resolves #7 / Alternative to #63
