### PR TITLE
Update sleep timer extended msg

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/bookdetails/AudiobookDetailsViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/bookdetails/AudiobookDetailsViewModel.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.combine
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 @ExperimentalCoroutinesApi
 class AudiobookDetailsViewModel(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,7 +173,7 @@
     <string name="sleep_timer_duration_end_of_chapter">End of chapter</string>
     <string name="sleep_timer_append">+5 minutes</string>
     <string name="cancel">Cancel</string>
-    <string name="sleep_timer_extended_message">Sleep timer extended</string>
+    <string name="sleep_timer_extended_message">Chronicle: Sleep timer extended</string>
 
     <!-- Bottom chooser -->
     <string name="tap_to_close_opened_menu">Tap to close opened menu</string>


### PR DESCRIPTION
This targets issue #94 - Adjusting the messaging of the text of extending the sleep timer to include the app name.

The goal of the change is to make it easier for the user to understand what app was displaying the text and why it is not the foreground app.

**When app is not the foreground app**
![Screenshot_20220918-221659](https://user-images.githubusercontent.com/740393/190944521-7ea28258-7299-4450-bd37-704a91e0e2be.png)

**When app is the foreground app**
![Screenshot_20220918-221237](https://user-images.githubusercontent.com/740393/190944583-743438d4-07ba-41ba-b776-0281860002bd.jpg)

I did have to also remove an unused import to pass the pre-commit hook