### PR TITLE
Fix for End of Chapter Sleep Timer

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
@@ -599,10 +599,10 @@ class CurrentlyPlayingViewModel(
                     }
                     R.string.sleep_timer_duration_end_of_chapter -> {
                         val duration = (
-                            (chapterDuration.value ?: 0L) - (
+                            ((chapterDuration.value ?: 0L) - (
                                 chapterProgress.value
                                     ?: 0L
-                                ) / prefsRepo.playbackSpeed
+                                )) / prefsRepo.playbackSpeed
                             ).toLong()
                         BEGIN to duration
                     }


### PR DESCRIPTION
Fixed order-of-operations issues where only the progress of chapter was having the playback speed applied during calculation.