### PR TITLE
Default thumbnail mode to square instead of rectangular

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/SharedPreferencesPrefsRepo.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/data/local/SharedPreferencesPrefsRepo.kt
@@ -155,8 +155,8 @@ interface PrefsRepo {
             VIEW_STYLE_TEXT_LIST
         )
 
-        const val BOOK_COVER_STYLE_RECT = "Rectangular"
         const val BOOK_COVER_STYLE_SQUARE = "Square"
+        const val BOOK_COVER_STYLE_RECT = "Rectangular"
     }
 }
 
@@ -186,7 +186,7 @@ class SharedPreferencesPrefsRepo @Inject constructor(private val sharedPreferenc
             value.absolutePath
         ).apply()
 
-    private val defaultBookCoverStyle = "Rectangular"
+    private val defaultBookCoverStyle = "Square"
     override var bookCoverStyle: String
         get() = getString(KEY_BOOK_COVER_STYLE, defaultBookCoverStyle)
         set(value) = sharedPreferences.edit().putString(KEY_BOOK_COVER_STYLE, value).apply()

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
@@ -599,10 +599,12 @@ class CurrentlyPlayingViewModel(
                     }
                     R.string.sleep_timer_duration_end_of_chapter -> {
                         val duration = (
-                            ((chapterDuration.value ?: 0L) - (
-                                chapterProgress.value
-                                    ?: 0L
-                                )) / prefsRepo.playbackSpeed
+                            (
+                                (chapterDuration.value ?: 0L) - (
+                                    chapterProgress.value
+                                        ?: 0L
+                                    )
+                                ) / prefsRepo.playbackSpeed
                             ).toLong()
                         BEGIN to duration
                     }

--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/settings/SettingsViewModel.kt
@@ -191,8 +191,8 @@ class SettingsViewModel(
                     override fun onClick() {
                         showOptionsMenu(
                             options = listOf(
-                                FormattableString.from(R.string.settings_book_cover_type_rect),
-                                FormattableString.from(R.string.settings_book_cover_type_square)
+                                FormattableString.from(R.string.settings_book_cover_type_square),
+                                FormattableString.from(R.string.settings_book_cover_type_rect)
                             ),
                             title = FormattableString.from(R.string.settings_book_cover_type_label),
                             listener = object : BottomChooserItemListener() {


### PR DESCRIPTION
Default thumbnail mode to square instead of rectangular. Swap order of thumbnail mode preference list to have the default option (square) listed first. Formatting to appease ktlint.