### PR TITLE
Accessible text colors

### DIFF
--- a/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
+++ b/app/src/main/java/io/github/mattpvaughn/chronicle/features/currentlyplaying/CurrentlyPlayingViewModel.kt
@@ -599,10 +599,12 @@ class CurrentlyPlayingViewModel(
                     }
                     R.string.sleep_timer_duration_end_of_chapter -> {
                         val duration = (
-                            ((chapterDuration.value ?: 0L) - (
-                                chapterProgress.value
-                                    ?: 0L
-                                )) / prefsRepo.playbackSpeed
+                            (
+                                (chapterDuration.value ?: 0L) - (
+                                    chapterProgress.value
+                                        ?: 0L
+                                    )
+                                ) / prefsRepo.playbackSpeed
                             ).toLong()
                         BEGIN to duration
                     }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,9 +4,9 @@
     <color name="colorPrimaryDark">#191A2A</color>
     <color name="colorAccent">#00B8D4</color>
     <color name="textPrimary">#D8FFFFFF</color>
-    <color name="textSecondary">#7BB998CC</color>
+    <color name="textSecondary">#9EE3D5EB</color>
     <color name="textActive">#00B8D4</color>
-    <color name="textActiveSecondary">#7B00B8D4</color>
+    <color name="textActiveSecondary">#9E81E8F7</color>
     <color name="textError">#FF4444</color>
     <color name="icon">@color/textPrimary</color>
     <color name="iconActive">@color/colorAccent</color>


### PR DESCRIPTION
Both secondary text colors now have >4.5:1 contrast ratio with the primary background, making them easier to read and WCAG AA compliant. textSecondary still has a touch of purple and textActiveSecondary is still cyan, both still able to be differentiated from their primary text colors while being lighter on the background.

Fixes #89 

![signal-2023-09-29-165323_002](https://github.com/mattttvaughn/chronicle/assets/7782373/303dd71b-2821-4a48-8282-6fcec5d76e52)
